### PR TITLE
Add additional ns to collect gatekeeper operator logs

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -62,6 +62,7 @@ gather_spoke () {
     oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
 
     oc adm inspect ns/openshift-gatekeeper-system --dest-dir=must-gather
+    oc adm inspect ns/openshift-operators --dest-dir=must-gather # gatekeeper operator will be installed in this ns in production
     oc adm inspect ns/openshift-gatekeeper-operator --dest-dir=must-gather
 }
 


### PR DESCRIPTION
Adds `ns/openshift-operators` namespace to collection on Managed Cluster. This will assist in debugging canary builds. 