### PR TITLE
backport fix, add observability-addon ns

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -55,6 +55,7 @@ gather_spoke () {
     oc adm inspect cispolicies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
 
     oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
+    oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
     
     oc adm inspect ns/openshift-gatekeeper-system --dest-dir=must-gather
     oc adm inspect ns/openshift-gatekeeper-operator --dest-dir=must-gather


### PR DESCRIPTION
**Issue:** https://github.com/open-cluster-management/backlog/issues/11138

**Description of Changes:**
Adding the open-cluster-management-addon-observability namespace to collection from must-gather. This change is present in 2.3 release, but was missing in 2.2 release. Backport.

**Is this a Hub or Managed cluster change?:** Managed 

**Notes:**
Documenting process for later reference.

How to backport:

1. Fork must gather project
2. `git checkout upstream/release-2.2`
3. `git checkout -B <branch-name>`
4. Make your change! (add observability-addon namespace to hub collection, )
5. Create pull request from **your forked branch** to **upstream release branch**
6. Click the green merge button, smile :) 
