### PR TITLE
Add observability addon namespace to managed collection

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -55,6 +55,7 @@ gather_spoke () {
     oc adm inspect cispolicies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
 
     oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
+    oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
     
     oc adm inspect ns/openshift-gatekeeper-system --dest-dir=must-gather
     oc adm inspect ns/openshift-gatekeeper-operator --dest-dir=must-gather


### PR DESCRIPTION
**Issue:** https://github.com/open-cluster-management/backlog/issues/11138

**Description of Changes:**
Adding the open-cluster-management-addon-observability namespace to collection from must-gather. This change is present in 2.3 release, but was missing in 2.2 release. Backport.

**Is this a Hub or Managed cluster change?:** Managed 

**Notes:**
Documenting process for later reference.

How to backport:

1. Clone upstream project `git clone`
2. Checkout Release Branch `git checkout release-2.2`
3. Branch from release Branch `git checkout -B <branch name>`
4. Make your change 
5. Create Pull request into release branch
6. smile :) 


