### PR TITLE
Collect data when OCM installed in non default namespace

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>
+
+**Description of Changes:**
+
+**What resource is being added**: 
+
+**Is this a Hub or Managed cluster change?:** 
+Hub Cluster | Managed Cluster
+
+**Notes:**
+

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -81,7 +81,7 @@ case "$CLUSTER" in
     #oc adm inspect  ns/open-cluster-management  --dest-dir=must-gather
     oc get pods -n "$HUBNAMESPACE" > ${BASE_COLLECTION_PATH}/gather-acm.log 
     oc adm inspect  ns/"$HUBNAMESPACE"  --dest-dir=must-gather
-    oc adm inspect  ns/"$HUBNAMESPACE"-hub  --dest-dir=must-gather
+    oc adm inspect  ns/open-cluster-management-hub  --dest-dir=must-gather
     # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485
     oc get proxy -o yaml > ${BASE_COLLECTION_PATH}/gather-proxy.log
     oc adm inspect  ns/hive  --dest-dir=must-gather


### PR DESCRIPTION
When acm is installed in a non default namespace, such as "xyz", our script erroneously checks for the namespace "xyz-hub" instead of "open-cluster-management-hub". This namespace name is fixed, and does not vary with the default namespace. This pull request changes this line of the collection script to use the hardcoded name instead of a variable. 

This pull request also adds a PR template for this repo.

Fix for issue https://github.com/open-cluster-management/backlog/issues/12919 and https://github.com/open-cluster-management/backlog/issues/13016