### PR TITLE
Collect data when OCM installed in non default namespace (release 2.1)

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -49,7 +49,7 @@ case "$CLUSTER" in
     #oc adm inspect  ns/open-cluster-management  --dest-dir=must-gather
     oc get pods -n "$HUBNAMESPACE" > ${BASE_COLLECTION_PATH}/gather-acm.log 
     oc adm inspect  ns/"$HUBNAMESPACE"  --dest-dir=must-gather
-    oc adm inspect  ns/"$HUBNAMESPACE"-hub  --dest-dir=must-gather
+    oc adm inspect  ns/open-cluster-management-hub  --dest-dir=must-gather
     # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485
     oc get proxy -o yaml > ${BASE_COLLECTION_PATH}/gather-proxy.log
     oc adm inspect  ns/hive  --dest-dir=must-gather


### PR DESCRIPTION
Fix for issue https://github.com/open-cluster-management/backlog/issues/12919 and https://github.com/open-cluster-management/backlog/issues/13016

This problem was also addressed in pr 64 and 66. This pull request backports the fix to release 2.1

When ocm is installed in a non default namespace, such as "xyz", our script erroneously checks for the namespace "xyz-hub" instead of "open-cluster-management-hub". This namespace name is fixed, and does not vary with the default namespace. This pull request changes this line of the collection script to use the hardcoded name instead of a variable. 
