### PR TITLE
policy automation missing from must gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -100,6 +100,7 @@ case "$CLUSTER" in
     oc adm inspect placementrules.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect subscriptions.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect policies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect policyautomations.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect placementbindings.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect clusterdeployments.hive.openshift.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect syncsets.hive.openshift.io --all-namespaces --dest-dir=must-gather


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>

**Description of Changes:**
GRC ansible automation CRs should be collected in mustgather.

**What resource is being added**: 
`policyautomations.policy.open-cluster-management.io`

**Is this a Hub or Managed cluster change?:** 
Hub Cluster | Managed Cluster
Hub

**Notes:**

