### PR TITLE
Added get csv to gather-acm.log at support engineer's request

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -79,7 +79,8 @@ case "$CLUSTER" in
 
     check_managed_clusters
     #oc adm inspect  ns/open-cluster-management  --dest-dir=must-gather
-    oc get pods -n "$HUBNAMESPACE" > ${BASE_COLLECTION_PATH}/gather-acm.log 
+    oc get pods -n "$HUBNAMESPACE" > ${BASE_COLLECTION_PATH}/gather-acm.log
+    oc get csv -n "$HUBNAMESPACE" > ${BASE_COLLECTION_PATH}/gather-acm.log 
     oc adm inspect  ns/"$HUBNAMESPACE"  --dest-dir=must-gather
     oc adm inspect  ns/open-cluster-management-hub  --dest-dir=must-gather
     # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#14554
Can't seem to create an issue
**Description of Changes:**
Added get csv in order to get easy view of what operators are installed in the namespace

**What resource is being added**: 
Operator information

**Is this a Hub or Managed cluster change?:** 
Hub Cluster

**Notes:**

