### PR TITLE
add cluster placement to collection

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -98,6 +98,8 @@ case "$CLUSTER" in
     oc adm inspect channels.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect deployables.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect helmreleases.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect placementdecisions.cluster.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect placements.cluster.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect placementrules.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect subscriptions.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect policies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>

**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/14907

**Description of Changes:**
Added collection of cluster placement CRs

**What resource is being added**: 

```
placementdecisions.cluster.open-cluster-management.io
placements.cluster.open-cluster-management.io
```

**Is this a Hub or Managed cluster change?:** 
Hub Cluster 

**Notes:**
Not specific to GRC so not sure why this wasn't already being collected.
